### PR TITLE
Typo in setTime->month documentation

### DIFF
--- a/ESP32Time.cpp
+++ b/ESP32Time.cpp
@@ -42,7 +42,7 @@ ESP32Time::ESP32Time(){
 	@param  hr
             hour of day (0-23)
     @param  mt
-            month (0-31)
+            month (1-12)
 	@param  yr
             year ie 2021
     @param  ms


### PR DESCRIPTION
Proper documentation as we need to know if month is between 0-11 or 1-12 - In `setTime ` its 1-12, in `getMonth` it's 0-11 which may cause confusion.