### PR TITLE
Ignore RTC_DATA_ATTR when it's absent

### DIFF
--- a/ESP32Time.cpp
+++ b/ESP32Time.cpp
@@ -26,7 +26,12 @@
 #include "time.h"
 #include <sys/time.h>
 
+#ifdef RTC_DATA_ATTR
 RTC_DATA_ATTR static bool overflow;
+#else
+static bool overflow;
+#endif
+
 
 /*!
     @brief  Constructor for ESP32Time


### PR DESCRIPTION
Fix #32 